### PR TITLE
Adbkeys directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
       https://dl.google.com/android/android-sdk_r24.0.2-linux.tgz && \
     tar xzf /opt/adt.tgz -C /opt && \
     rm /opt/adt.tgz && \
-    echo y | /opt/android-sdk-linux/tools/android update sdk --filter platform-tools --no-ui --force && \
+    echo y|/opt/android-sdk-linux/tools/android update sdk --no-ui --all --filter platform-tools && \    
     apt-get clean && \
     rm -rf /var/cache/apt/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM ubuntu:14.04
 MAINTAINER Simo Kinnunen
 
-# Set up insecure default key
-RUN mkdir -m 0750 /.android
-ADD files/insecure_shared_adbkey /.android/adbkey
-ADD files/insecure_shared_adbkey.pub /.android/adbkey.pub
-
 # Note: ADB needs 32-bit libs
 RUN export DEBIAN_FRONTEND=noninteractive && \
     dpkg --add-architecture i386 && \
@@ -19,6 +14,10 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     echo y | /opt/android-sdk-linux/tools/android update sdk --filter platform-tools --no-ui --force && \
     apt-get clean && \
     rm -rf /var/cache/apt/*
+
+# Set up insecure default key
+ADD files/insecure_shared_adbkey /root/.android/adbkey
+ADD files/insecure_shared_adbkey.pub /root/.android/adbkey.pub
 
 # Expose default ADB port
 EXPOSE 5037

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a [Dockerfile](https://www.docker.io/) for the [Android
 
 ## Security
 
-The container is preloaded with an RSA key for authentication, so that you won't have to accept a new key on the device every time you run the container (normally the key is generated on-demand by the adb binary). While convenient, it means that your device will be accessible over ADB to others who possess the key. You can supply your own keys by using `-v /your/key_folder:/.android` with `docker run`.
+The container is preloaded with an RSA key for authentication, so that you won't have to accept a new key on the device every time you run the container (normally the key is generated on-demand by the adb binary). While convenient, it means that your device will be accessible over ADB to others who possess the key. You can supply your own keys by using `-v /your/key_folder:/root/.android` with `docker run`.
 
 ## Usage
 


### PR DESCRIPTION
Fix https://github.com/sorccu/docker-adb/issues/5

I had to update the Dockerfile also for platform-tools installation because the previous Dockerfile was not working, probably because the the list of android sdk updates has changed since last time that Dockerfile was made.

Tested. It's working as expected